### PR TITLE
Simplify Windows CMake presets structure

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,7 +12,7 @@ jobs:
         compiler: [msvc, clang]
         include:
           - compiler: msvc
-            preset: windows-msvc-debug-user-mode
+            preset: windows-msvc-debug
           - compiler: clang
             preset: windows-clang-debug
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -66,32 +66,8 @@
       }
     },
     {
-      "name": "windows-msvc-debug-developer-mode",
-      "displayName": "msvc Debug (Developer Mode)",
-      "description": "Target Windows with the msvc compiler, debug build type",
-      "inherits": "conf-windows-common",
-      "cacheVariables": {
-        "CMAKE_C_COMPILER": "cl",
-        "CMAKE_CXX_COMPILER": "cl",
-        "CMAKE_BUILD_TYPE": "Debug",
-        "ENABLE_DEVELOPER_MODE": "ON"
-      }
-    },
-    {
-      "name": "windows-msvc-release-developer-mode",
-      "displayName": "msvc Release (Developer Mode)",
-      "description": "Target Windows with the msvc compiler, release build type",
-      "inherits": "conf-windows-common",
-      "cacheVariables": {
-        "CMAKE_C_COMPILER": "cl",
-        "CMAKE_CXX_COMPILER": "cl",
-        "CMAKE_BUILD_TYPE": "Release",
-        "ENABLE_DEVELOPER_MODE": "ON"
-      }
-    },
-    {
-      "name": "windows-msvc-debug-user-mode",
-      "displayName": "msvc Debug (User Mode)",
+      "name": "windows-msvc-debug",
+      "displayName": "msvc Debug",
       "description": "Target Windows with the msvc compiler, debug build type",
       "inherits": "conf-windows-common",
       "cacheVariables": {
@@ -102,8 +78,8 @@
       }
     },
     {
-      "name": "windows-msvc-release-user-mode",
-      "displayName": "msvc Release (User Mode)",
+      "name": "windows-msvc-release",
+      "displayName": "msvc Release",
       "description": "Target Windows with the msvc compiler, release build type",
       "inherits": "conf-windows-common",
       "cacheVariables": {
@@ -204,18 +180,18 @@
       }
     },
     {
-      "name": "test-windows-msvc-debug-developer-mode",
+      "name": "test-windows-msvc-debug",
       "displayName": "Strict",
       "description": "Enable output and stop on failure",
       "inherits": "test-common",
-      "configurePreset": "windows-msvc-debug-developer-mode"
+      "configurePreset": "windows-msvc-debug"
     },
     {
-      "name": "test-windows-msvc-release-developer-mode",
+      "name": "test-windows-msvc-release",
       "displayName": "Strict",
       "description": "Enable output and stop on failure",
       "inherits": "test-common",
-      "configurePreset": "windows-msvc-release-developer-mode"
+      "configurePreset": "windows-msvc-release"
     },
     {
       "name": "test-windows-clang-debug",


### PR DESCRIPTION
This PR streamlines our CMake preset configuration for Windows builds by:

- Removing redundant developer-mode presets for MSVC builds
- Simplifying preset names by removing the "-user-mode" suffix
- Updating the Windows build workflow to use the new preset names

These changes make our build configuration more straightforward and easier to maintain, while preserving all existing functionality. The default builds now use the non-developer mode settings, which is the more common use case.

Changes:
- Removed: windows-msvc-debug-developer-mode
- Removed: windows-msvc-release-developer-mode
- Renamed: windows-msvc-debug-user-mode → windows-msvc-debug
- Renamed: windows-msvc-release-user-mode → windows-msvc-release
- Updated corresponding test presets
- Updated build-windows.yml workflow