### PR TITLE
fix: correct std::span template deduction for fixed-size arrays

### DIFF
--- a/src/psm/include/psm/psm.hpp
+++ b/src/psm/include/psm/psm.hpp
@@ -25,7 +25,9 @@ template <typename SrcFormat, typename DstFormat,
           std::ranges::contiguous_range Src_Range,
           std::ranges::contiguous_range Dst_Range>
 void Convert(Src_Range& src, Dst_Range& dst) {
-  detail::ConvertImpl<SrcFormat, DstFormat>(std::span{src}, std::span{dst});
+  detail::ConvertImpl<SrcFormat, DstFormat>(
+      std::span<std::ranges::range_value_t<Src_Range>>{src.data(), src.size()},
+      std::span<std::ranges::range_value_t<Dst_Range>>{dst.data(), dst.size()});
 }
 
 }  // namespace psm


### PR DESCRIPTION
## Description
Fixed template argument deduction issue when using std::span with fixed-size arrays in the Convert function. 
The previous implementation failed to properly handle std::array and other fixed-size contiguous ranges.

## Changes
- Modified Convert function to explicitly create spans using data() and size()
- Added support for fixed-size containers like std::array
- Improved type deduction using std::ranges::range_value_t

## Testing
Tested with:
- std::array<unsigned char, 12>
- std::vector<unsigned char>
- Raw arrays via std::span
- std::basic_string<unsigned char>