### PR TITLE
chore: remove unnecessary include dependencies

### DIFF
--- a/src/psm_cli/psm_cli.cpp
+++ b/src/psm_cli/psm_cli.cpp
@@ -1,9 +1,9 @@
+#include <cstddef>
 #include <format>
 #include <iostream>
 #include <ranges>
 #include <vector>
 
-#include "psm/orgb.hpp"
 #include "psm/psm.hpp"
 
 template <std::ranges::contiguous_range Buffer>


### PR DESCRIPTION
Clean up include dependencies by removing unused headers. This helps reduce compilation time and improves code clarity.
