### PR TITLE
refactor(orgb): remove unused scaleTo4d function

### DIFF
--- a/src/psm/orgb/orgb.cpp
+++ b/src/psm/orgb/orgb.cpp
@@ -15,13 +15,6 @@ using Mat4fView = Eigen::Map<Mat4f>;
 using RowXf = Eigen::RowVectorXf;
 using RowXfView = Eigen::Map<RowXf>;
 
-Mat4f scaleTo4d(const Mat3f& lcc, const Eigen::MatrixXf& alpha) {
-  Mat4f rgba(lcc.rows(), 4);
-  rgba.leftCols(3) = lcc;
-  rgba.col(rgba.cols() - 1) = alpha;
-  return rgba;
-}
-
 Mat3f switch_rb(Mat3f src) {
   Mat3f bgr(src.rows(), 3);
   bgr.col(0) = src.col(2);


### PR DESCRIPTION
The scaleTo4d function was intended for handling 4-channel images, which is no longer supported. Removing it to avoid confusion and potential misuse.