### PR TITLE
chore: add .gitattributes for consistent C++ line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Explicitly declare C++ source and header files to always be normalized
+# and converted to native line endings on checkout.
+*.cpp text
+*.hpp text
+*.h text
+*.c text
+*.cc text
+*.cxx text
+*.hh text
+*.hxx text
+
+# Normalize common text files
+*.txt text
+*.md text
+*.cmake text
+*.in text
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.exe binary
+*.dll binary
+*.so binary
+*.a binary
+*.lib binary
+*.o binary
+*.obj binary 


### PR DESCRIPTION
### Summary

This pull request adds a `.gitattributes` file to enforce consistent line endings for C++ source and header files, as well as other text files. This ensures that all text files use the same line endings, regardless of the operating system.
By using `.gitattributes`, we can prevent line ending issues that arise when collaborating across different operating systems, such as Windows (CRLF) and Linux (LF). This change will help maintain a consistent codebase and improve cross-platform compatibility.

### Issue

Closes #22 