### PR TITLE
refactor(psm): simplify AdjustChannels interface

### DIFF
--- a/src/psm/CMakeLists.txt
+++ b/src/psm/CMakeLists.txt
@@ -17,4 +17,4 @@ target_sources(
          include/psm/percent.hpp
          ${CMAKE_BINARY_DIR}/include/psm/version.hpp)
 
-target_link_libraries(psm INTERFACE psm_orgb psm_srgb)
+target_link_libraries(psm INTERFACE psm_orgb psm_srgb psm_detail)

--- a/src/psm/include/psm/orgb.hpp
+++ b/src/psm/include/psm/orgb.hpp
@@ -17,9 +17,6 @@ class Orgb {
   static void fromSRGB(const std::span<T>& src, std::span<T> dst);
   template <typename T>
   static void toSRGB(const std::span<T>& src, std::span<T> dst);
-  template <typename T>
-  static void adjustChannels(std::span<T> buffer,
-                             const Percent& adjust_percentage);
 };
 
 template <>

--- a/src/psm/include/psm/psm.hpp
+++ b/src/psm/include/psm/psm.hpp
@@ -4,6 +4,7 @@
 #include <span>
 
 #include "color_space_traits.hpp"
+#include "detail/adjust_channels.hpp"
 #include "orgb.hpp"
 #include "percent.hpp"
 #include "srgb.hpp"
@@ -19,9 +20,9 @@ void ConvertImpl(std::span<T> src, std::span<T> dst) {
   ColorSpace_t<DstFormat>::fromSRGB(intermediate, dst);
 }
 
-template <typename Format, typename T>
+template <typename T>
 void AdjustChannelsImpl(std::span<T> buffer, const Percent& adjust_percentage) {
-  ColorSpace_t<Format>::adjustChannels(buffer, adjust_percentage);
+  detail::adjustChannels(buffer, adjust_percentage);
 }
 }  // namespace detail
 
@@ -34,9 +35,9 @@ void Convert(SrcRange& src, DstRange& dst) {
       std::span<std::ranges::range_value_t<DstRange>>{dst.data(), dst.size()});
 }
 
-template <typename Format, std::ranges::contiguous_range Range>
+template <std::ranges::contiguous_range Range>
 void AdjustChannels(Range& buffer, const Percent& adjust_percentage) {
-  detail::AdjustChannelsImpl<Format>(std::span{buffer}, adjust_percentage);
+  detail::AdjustChannelsImpl(std::span{buffer}, adjust_percentage);
 }
 
 }  // namespace psm

--- a/src/psm/include/psm/srgb.hpp
+++ b/src/psm/include/psm/srgb.hpp
@@ -22,10 +22,6 @@ class Srgb {
   static void toSRGB(const std::span<T>& src, std::span<T> dst) {
     dst = src;  // passthrough cuz we are already in sRGB
   }
-
-  template <typename T>
-  static void adjustChannels(std::span<T> buffer,
-                             const Percent& adjust_percentage);
 };
 
 template <>

--- a/src/psm/orgb/orgb.cpp
+++ b/src/psm/orgb/orgb.cpp
@@ -4,8 +4,6 @@
 #include <cmath>
 #include <numbers>
 
-#include "psm/detail/adjust_channels.hpp"
-
 namespace {
 
 using Mat3f = Eigen::Matrix<float, Eigen::Dynamic, 3, Eigen::RowMajor>;
@@ -168,17 +166,8 @@ void Orgb::toSRGB(const std::span<T>& src, std::span<T> dst) {
       (result * 255.0f).cwiseMin(255.0f).cwiseMax(0.0f).template cast<T>();
 }
 
-template <typename T>
-void Orgb::adjustChannels(std::span<T> buffer,
-                          const Percent& adjust_percentage) {
-  detail::adjustChannels(buffer, adjust_percentage);
-}
-
 template void Orgb::fromSRGB<unsigned char>(const std::span<unsigned char>&,
                                             std::span<unsigned char>);
 template void Orgb::toSRGB<unsigned char>(const std::span<unsigned char>&,
                                           std::span<unsigned char>);
-
-template void Orgb::adjustChannels<unsigned char>(std::span<unsigned char>,
-                                                  const Percent&);
 }  // namespace psm

--- a/src/psm/srgb/srgb.cpp
+++ b/src/psm/srgb/srgb.cpp
@@ -1,20 +1,9 @@
 #include "psm/srgb.hpp"
 
-#include "psm/detail/adjust_channels.hpp"
-
 namespace psm {
-
-template <typename T>
-void Srgb::adjustChannels(std::span<T> buffer,
-                          const Percent& adjust_percentage) {
-  detail::adjustChannels(buffer, adjust_percentage);
-}
 
 template void Srgb::fromSRGB<unsigned char>(const std::span<unsigned char>&,
                                             std::span<unsigned char>);
 template void Srgb::toSRGB<unsigned char>(const std::span<unsigned char>&,
                                           std::span<unsigned char>);
-template void Srgb::adjustChannels<unsigned char>(std::span<unsigned char>,
-                                                  const Percent&);
-
 }  // namespace psm

--- a/src/psm_cli/psm_cli.cpp
+++ b/src/psm_cli/psm_cli.cpp
@@ -28,7 +28,7 @@ int main() {
   print_buffer(input_image);
 
   psm::Convert<psm::sRGB, psm::oRGB>(input_image, output_image);
-  psm::AdjustChannels<psm::oRGB>(output_image, {0, 20, 20});
+  psm::AdjustChannels(output_image, {0, 20, 20});
   psm::Convert<psm::oRGB, psm::sRGB>(output_image, output_image);
 
   std::cout << "Output Image (BGR):\n";


### PR DESCRIPTION
### Summary
- Removed color space template parameter from `AdjustChannels` function since it's not needed for percentage-based adjustments
- Centralized channel adjustment logic in detail namespace
- Removed duplicate `adjustChannels` implementations from color space classes
- Updated usage in CLI example from `AdjustChannels<psm::oRGB>` to simply `AdjustChannels`

### Issue
Closes #24 