### PR TITLE
refactor(psm)!: change Percent type from float to int

### DIFF
--- a/src/psm/adjust_channels/adjust_channels.cpp
+++ b/src/psm/adjust_channels/adjust_channels.cpp
@@ -12,9 +12,9 @@ void adjustChannels(std::span<T> buffer, const Percent& adjust_percentage) {
       map_src.data(), buffer.size() / 3, 3);
 
   Eigen::Array<float, 1, 3> adjustments;
-  adjustments << adjust_percentage.channel0_ / 100.0f,
-      adjust_percentage.channel1_ / 100.0f,
-      adjust_percentage.channel2_ / 100.0f;
+  adjustments << static_cast<float>(adjust_percentage.channel0_) / 100.0f,
+      static_cast<float>(adjust_percentage.channel1_) / 100.0f,
+      static_cast<float>(adjust_percentage.channel2_) / 100.0f;
 
   split_src = (split_src.template cast<float>().array() *
                (1.0f + adjustments.replicate(split_src.rows(), 1)))

--- a/src/psm/include/psm/percent.hpp
+++ b/src/psm/include/psm/percent.hpp
@@ -3,9 +3,9 @@
 namespace psm {
 
 struct Percent {
-  float channel0_;
-  float channel1_;
-  float channel2_;
+  int channel0_;
+  int channel1_;
+  int channel2_;
 };
 
 }  // namespace psm

--- a/src/psm_cli/psm_cli.cpp
+++ b/src/psm_cli/psm_cli.cpp
@@ -30,7 +30,7 @@ int main() {
   print_buffer(input_image);
 
   psm::Convert<psm::sRGB, psm::AdobeRGB>(input_image, output_image);
-  psm::AdjustChannels(output_image, psm::Percent(20.0f, 0.0f, 10.0f));
+  psm::AdjustChannels(output_image, psm::Percent(20, 0, 10));
   psm::Convert<psm::AdobeRGB, psm::sRGB>(output_image, output_image);
 
   std::cout << "Output Image (BGR):\n";


### PR DESCRIPTION
> [!IMPORTANT]
> BREAKING CHANGE: Percent struct now uses int instead of float for channel values.

- Modified Percent struct to use int instead of float for channel values
- Updated adjustChannels to handle int-based percentages with explicit casting
- No functional changes since percentages were already being used as whole numbers

## Motivation:
The percentage values were only being used as whole numbers (e.g., 50% not 50.5%), 
so using float was unnecessary. This change makes the API more explicit about the 
expected input format.

## Related Issues
Closes #48 