### PR TITLE
fix(srgb): correct data copying in color space conversion

### DIFF
--- a/src/psm/include/psm/detail/srgb.hpp
+++ b/src/psm/include/psm/detail/srgb.hpp
@@ -11,12 +11,14 @@ class Srgb {
 
   template <typename T>
   static void fromSRGB(const std::span<T>& src, std::span<T> dst) {
-    dst = src;  // passthrough because we are already in sRGB
+    // passthrough because we are already in sRGB
+    std::copy(src.begin(), src.end(), dst.begin());
   }
 
   template <typename T>
   static void toSRGB(const std::span<T>& src, std::span<T> dst) {
-    dst = src;  // passthrough because we are already in sRGB
+    // passthrough because we are already in sRGB
+    std::copy(src.begin(), src.end(), dst.begin());
   }
 };
 


### PR DESCRIPTION
Fix incorrect buffer handling in color space conversion where:

Problem
- Span assignment (`dst = src`) only rebinds the reference
- Intermediate buffers remain empty in multi-step conversions
- Data isn't actually copied between buffers

Solution
- Replace span assignment with proper std::copy
- Ensure actual data copying between buffers
- Maintain data integrity in multi-step conversions

Closes #61 