### PR TITLE
feat: add ProPhotoRGB color space support

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -1,4 +1,4 @@
-set(PSM_MODULES adjust_channels orgb adobe_rgb display_p3)
+set(PSM_MODULES adjust_channels orgb adobe_rgb display_p3 pro_photo_rgb)
 
 # Dynamically create WITH_<module> options
 foreach(module ${PSM_MODULES})

--- a/src/psm/include/psm/detail/pro_photo_rgb.hpp
+++ b/src/psm/include/psm/detail/pro_photo_rgb.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <span>
+
+namespace psm {
+
+namespace detail {
+
+class ProPhotoRgb {
+ public:
+  ProPhotoRgb() = delete;
+
+  template <typename T>
+  static void fromSRGB(const std::span<const T>& src, std::span<T> dst);
+  template <typename T>
+  static void toSRGB(const std::span<const T>& src, std::span<T> dst);
+};
+
+}  // namespace detail
+
+struct ProPhotoRGB {
+  using type = detail::ProPhotoRgb;
+};
+
+}  // namespace psm

--- a/src/psm/include/psm/psm.hpp
+++ b/src/psm/include/psm/psm.hpp
@@ -13,6 +13,9 @@
 #if __has_include("detail/display_p3.hpp")
 #include "detail/display_p3.hpp"
 #endif
+#if __has_include("detail/pro_photo_rgb.hpp")
+#include "detail/pro_photo_rgb.hpp"
+#endif
 
 #include "detail/color_space_concept.hpp"
 #include "detail/srgb.hpp"

--- a/src/psm/pro_photo_rgb/CMakeLists.txt
+++ b/src/psm/pro_photo_rgb/CMakeLists.txt
@@ -1,0 +1,12 @@
+psm_add_module(psm_pro_photo_rgb SHARED)
+
+target_sources(
+  psm_pro_photo_rgb
+  PRIVATE pro_photo_rgb.cpp
+  PUBLIC FILE_SET HEADERS BASE_DIRS ${CMAKE_SOURCE_DIR}/src/psm/include FILES
+         ${CMAKE_SOURCE_DIR}/src/psm/include/psm/detail/pro_photo_rgb.hpp)
+
+find_package(Eigen3 REQUIRED)
+
+target_link_libraries(psm_pro_photo_rgb PRIVATE Eigen3::Eigen psm_srgb)
+target_compile_features(psm_pro_photo_rgb PUBLIC cxx_std_20)

--- a/src/psm/pro_photo_rgb/pro_photo_rgb.cpp
+++ b/src/psm/pro_photo_rgb/pro_photo_rgb.cpp
@@ -1,0 +1,115 @@
+#include "psm/detail/pro_photo_rgb.hpp"
+
+#include <Eigen/Dense>
+#include <cmath>
+
+#include "psm/detail/colorspace.hpp"
+#include "psm/detail/pixel_transformation.hpp"
+#include "psm/detail/types.hpp"
+
+namespace {
+
+psm::detail::Mat3f xyz2pro_photo_rgb(const psm::detail::Mat3f& src) {
+  Eigen::Matrix3f transform_mat;
+  // clang-format off
+  transform_mat << 1.3460f, -0.2556f, -0.0511f,
+                  -0.5446f,  1.5082f,  0.0205f,
+                   0.0f,     0.0f,     1.2123f;
+  // clang-format on
+  return src * transform_mat.transpose();
+}
+
+psm::detail::Mat3f pro_photo_rgb2xyz(const psm::detail::Mat3f& src) {
+  Eigen::Matrix3f transform_mat;
+  // clang-format off
+  transform_mat << 0.7974f,   0.1352f,   0.03131f,
+                   0.2880f,   0.7118f,   0.00008f,
+                   0.0f,      0.0f,      0.8251f;
+  // clang-format on
+  return src * transform_mat.transpose();
+}
+
+}  // namespace
+
+namespace psm::detail {
+
+template <typename T>
+void ProPhotoRgb::fromSRGB(const std::span<const T>& src, std::span<T> dst) {
+  const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
+  psm::detail::RowXf norm_src = transform::srgb::decode(map_src);
+
+  // Assuming RGB/BGR as input
+  const psm::detail::Mat3fView norm_rgb(norm_src.data(), norm_src.cols() / 3,
+                                        3);
+  const psm::detail::Mat3f xyz65 = psm::detail::srgbToXyz(norm_rgb);
+
+  // Bradford chromatic adaptation matrix from D65 to D50
+  Eigen::Matrix3f bradford;
+  // clang-format off
+  bradford << 1.0478f, 0.0229f, -0.0501f,
+             0.0295f, 0.9904f, -0.0170f,
+            -0.0092f, 0.0150f,  0.7521f;
+  // clang-format on
+  const psm::detail::Mat3f xyz50 = xyz65 * bradford.transpose();
+
+  const psm::detail::Mat3f pro_photo_rgb = xyz2pro_photo_rgb(xyz50);
+
+  const Eigen::Map<const psm::detail::RowXf> pro_photo_rgb_row(
+      pro_photo_rgb.data(), pro_photo_rgb.rows() * pro_photo_rgb.cols());
+
+  psm::detail::RowXf encoded_pro_photo_rgb =
+      pro_photo_rgb_row.unaryExpr([](float value) {
+        return (value < 1.0f / 512.0f) ? (16 * value)
+                                       : (std::pow(value, 1.0f / 1.8f));
+      });
+
+  const psm::detail::Mat3fView result(encoded_pro_photo_rgb.data(),
+                                      encoded_pro_photo_rgb.size() / 3, 3);
+
+  Eigen::Map<Eigen::RowVectorX<T>> dst_map(dst.data(), dst.size());
+  dst_map = psm::detail::denormalize_as<T>(result);
+}
+
+template <typename T>
+void ProPhotoRgb::toSRGB(const std::span<const T>& src, std::span<T> dst) {
+  const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
+  psm::detail::RowXf norm_src = psm::detail::normalize(map_src);
+
+  psm::detail::RowXf decoded_pro_photo = norm_src.unaryExpr([](float value) {
+    return (value < 16.0f / 512.0f) ? (value / 16.0f) : (std::pow(value, 1.8f));
+  });
+
+  // Assuming RGB/BGR as input
+  const psm::detail::Mat3fView pro_photo_rgb(decoded_pro_photo.data(),
+                                             decoded_pro_photo.cols() / 3, 3);
+
+  const psm::detail::Mat3f xyz50 = pro_photo_rgb2xyz(pro_photo_rgb);
+
+  // Bradford chromatic adaptation matrix from D50 to D65 (inverse of D65->D50)
+  Eigen::Matrix3f bradford_inverse;
+  // clang-format off
+  bradford_inverse << 0.9555766, -0.0230393, 0.0631636,
+                     -0.0282895,  1.0099416, 0.0210077,
+                      0.0122982, -0.0204830, 1.3299098;
+  // clang-format on
+
+  const psm::detail::Mat3f xyz65 = xyz50 * bradford_inverse.transpose();
+
+  const psm::detail::Mat3f srgb = psm::detail::xyzToSrgb(xyz65);
+
+  const Eigen::Map<const psm::detail::RowXf> srgb_row(
+      srgb.data(), srgb.rows() * srgb.cols());
+  psm::detail::RowXf encoded_srgb = transform::srgb::encode(srgb_row);
+
+  const psm::detail::Mat3fView result(encoded_srgb.data(),
+                                      encoded_srgb.size() / 3, 3);
+
+  Eigen::Map<Eigen::RowVectorX<T>> dst_map(dst.data(), dst.size());
+  dst_map = psm::detail::denormalize_as<T>(result);
+}
+
+template void ProPhotoRgb::fromSRGB<unsigned char>(
+    const std::span<const unsigned char>&, std::span<unsigned char>);
+template void ProPhotoRgb::toSRGB<unsigned char>(
+    const std::span<const unsigned char>&, std::span<unsigned char>);
+}  // namespace psm::detail

--- a/test/psm/CMakeLists.txt
+++ b/test/psm/CMakeLists.txt
@@ -22,3 +22,7 @@ endif()
 if(TARGET psm_orgb)
   add_subdirectory(orgb)
 endif()
+
+if(TARGET psm_pro_photo_rgb)
+  add_subdirectory(pro_photo_rgb)
+endif()

--- a/test/psm/pro_photo_rgb/CMakeLists.txt
+++ b/test/psm/pro_photo_rgb/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(pro_photo_rgb_test pro_photo_rgb_test.cpp)
+
+target_link_libraries(pro_photo_rgb_test PRIVATE psm::pro_photo_rgb
+                                                 psm_test_utils)
+
+addtests(pro_photo_rgb_test)

--- a/test/psm/pro_photo_rgb/pro_photo_rgb_test.cpp
+++ b/test/psm/pro_photo_rgb/pro_photo_rgb_test.cpp
@@ -1,0 +1,119 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <vector>
+
+#include "psm/psm.hpp"
+#include "test_utils.hpp"
+
+namespace psm_test::pro_photo_rgb {
+
+class ProPhotoRgbTest : public ::testing::Test {
+ protected:
+  static constexpr int Tolerance = 2;
+
+  std::vector<unsigned char> red{255, 0, 0};
+  std::vector<unsigned char> green{0, 255, 0};
+  std::vector<unsigned char> blue{0, 0, 255};
+  std::vector<unsigned char> black{0, 0, 0};
+  std::vector<unsigned char> white{255, 255, 255};
+
+  std::vector<unsigned char> pro_photo_red{179, 70, 26};
+  std::vector<unsigned char> pro_photo_green{137, 237, 77};
+  std::vector<unsigned char> pro_photo_blue{86, 35, 235};
+  std::vector<unsigned char> pro_photo_black{0, 0, 0};
+  // Result buffer
+  std::vector<unsigned char> result{0, 0, 0};
+
+  void SetUp() override {}
+};
+
+TEST_F(ProPhotoRgbTest, HandlesPrimaryColors) {
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(red, result);
+  EXPECT_THAT(result, IsNearVector(pro_photo_red, Tolerance));
+
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(green, result);
+  EXPECT_THAT(result, IsNearVector(pro_photo_green, Tolerance));
+
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(blue, result);
+  EXPECT_THAT(result, IsNearVector(pro_photo_blue, Tolerance));
+}
+
+TEST_F(ProPhotoRgbTest, HandlesBlackAndWhite) {
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(black, result);
+  EXPECT_EQ(result, pro_photo_black);
+
+  const std::vector<unsigned char> near_black{1, 1, 1};
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(near_black, result);
+  EXPECT_LT(result[0], 2);
+  EXPECT_LT(result[1], 2);
+  EXPECT_LT(result[2], 2);
+
+  const std::vector<unsigned char> near_white{254, 254, 254};
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(near_white, result);
+  EXPECT_LT(result[0], 255);
+  EXPECT_LT(result[1], 255);
+  EXPECT_LT(result[2], 255);
+}
+
+TEST_F(ProPhotoRgbTest, HandlesGrayValues) {
+  const std::vector<unsigned char> mid_gray{128, 128, 128};
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(mid_gray, result);
+  EXPECT_THAT(result, IsNearVector(std::vector<unsigned char>{108, 108, 108},
+                                   Tolerance));
+
+  const std::vector<unsigned char> quarter_gray{64, 64, 64};
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(quarter_gray, result);
+  EXPECT_THAT(result,
+              IsNearVector(std::vector<unsigned char>{48, 48, 48}, Tolerance));
+
+  const std::vector<unsigned char> three_quarter_gray{192, 192, 192};
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(three_quarter_gray, result);
+  EXPECT_THAT(result, IsNearVector(std::vector<unsigned char>{177, 177, 177},
+                                   Tolerance));
+}
+
+TEST_F(ProPhotoRgbTest, RoundTripConversion) {
+  const std::vector<unsigned char> original = {210, 92, 180};
+  std::vector<unsigned char> intermediate(3);
+  std::vector<unsigned char> result(3);
+
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(original, intermediate);
+  psm::Convert<psm::ProPhotoRGB, psm::sRGB>(intermediate, result);
+
+  EXPECT_THAT(result, IsNearVector(original, Tolerance));
+}
+
+TEST_F(ProPhotoRgbTest, ValidatesInputSize) {
+  const std::vector<unsigned char> invalid_size = {255,
+                                                   255};  // Only 2 components
+  std::vector<unsigned char> result(3);
+
+  EXPECT_THROW(
+      (psm::Convert<psm::sRGB, psm::ProPhotoRGB>(invalid_size, result)),
+      std::invalid_argument);
+}
+
+TEST_F(ProPhotoRgbTest, ValidatesOutputBuffer) {
+  const std::vector<unsigned char> input = {255, 255, 255};
+  std::vector<unsigned char> small_output(2);
+
+  EXPECT_THROW((psm::Convert<psm::sRGB, psm::ProPhotoRGB>(input, small_output)),
+               std::invalid_argument);
+}
+
+TEST_F(ProPhotoRgbTest, BulkConversionPerformance) {
+  constexpr size_t num_pixels = 1000000;
+  const std::vector<unsigned char> large_input(num_pixels * 3, 128);
+  std::vector<unsigned char> large_output(num_pixels * 3);
+
+  auto start = std::chrono::high_resolution_clock::now();
+  psm::Convert<psm::sRGB, psm::ProPhotoRGB>(large_input, large_output);
+  auto end = std::chrono::high_resolution_clock::now();
+
+  auto duration =
+      std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+  EXPECT_LT(duration.count(), 1000);  // Should complete within 1 second
+}
+
+}  // namespace psm_test::pro_photo_rgb


### PR DESCRIPTION
## What:
This PR adds support for the **ProPhotoRGB** color space to the **PSM** library, including bidirectional conversion between **ProPhotoRGB** and **sRGB**.
## Why:
ProPhotoRGB is a wide-gamut color space widely used in professional photography workflows. Adding support for this color space enhances the library's capabilities for users working with high-quality photographic content and color-critical applications.
## How:
- Implements the **ProPhotoRgb** conversion class with proper transformation matrices
- Uses **Bradford** chromatic adaptation for **D65** to **D50** white point conversion
- Adds complete test suite verifying conversion accuracy and performance
## Related Issues
Closes #44 