### PR TITLE
refactor: remove unnecessary references to std::span parameters

### DIFF
--- a/src/psm/adobe_rgb/adobe_rgb.cpp
+++ b/src/psm/adobe_rgb/adobe_rgb.cpp
@@ -77,8 +77,8 @@ void AdobeRgb::toSRGB(std::span<const T> src, std::span<T> dst) {
   dst_map = psm::detail::denormalize_as<T>(result);
 }
 
-template void AdobeRgb::fromSRGB<unsigned char>(
-    std::span<const unsigned char>, std::span<unsigned char>);
-template void AdobeRgb::toSRGB<unsigned char>(
-    std::span<const unsigned char>, std::span<unsigned char>);
+template void AdobeRgb::fromSRGB<unsigned char>(std::span<const unsigned char>,
+                                                std::span<unsigned char>);
+template void AdobeRgb::toSRGB<unsigned char>(std::span<const unsigned char>,
+                                              std::span<unsigned char>);
 }  // namespace psm::detail

--- a/src/psm/adobe_rgb/adobe_rgb.cpp
+++ b/src/psm/adobe_rgb/adobe_rgb.cpp
@@ -33,7 +33,7 @@ psm::detail::Mat3f adobe_rgb2xyz(const psm::detail::Mat3f& src) {
 namespace psm::detail {
 
 template <typename T>
-void AdobeRgb::fromSRGB(const std::span<const T>& src, std::span<T> dst) {
+void AdobeRgb::fromSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
   psm::detail::RowXf norm_src = transform::srgb::decode(map_src);
 
@@ -56,7 +56,7 @@ void AdobeRgb::fromSRGB(const std::span<const T>& src, std::span<T> dst) {
 }
 
 template <typename T>
-void AdobeRgb::toSRGB(const std::span<const T>& src, std::span<T> dst) {
+void AdobeRgb::toSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
   psm::detail::RowXf norm_src = transform::srgb::decode(map_src);
 
@@ -78,7 +78,7 @@ void AdobeRgb::toSRGB(const std::span<const T>& src, std::span<T> dst) {
 }
 
 template void AdobeRgb::fromSRGB<unsigned char>(
-    const std::span<const unsigned char>&, std::span<unsigned char>);
+    std::span<const unsigned char>, std::span<unsigned char>);
 template void AdobeRgb::toSRGB<unsigned char>(
-    const std::span<const unsigned char>&, std::span<unsigned char>);
+    std::span<const unsigned char>, std::span<unsigned char>);
 }  // namespace psm::detail

--- a/src/psm/display_p3/display_p3.cpp
+++ b/src/psm/display_p3/display_p3.cpp
@@ -79,8 +79,8 @@ void DisplayP3::toSRGB(std::span<const T> src, std::span<T> dst) {
   dst_map = psm::detail::denormalize_as<T>(result);
 }
 
-template void DisplayP3::fromSRGB<unsigned char>(
-    std::span<const unsigned char>, std::span<unsigned char>);
-template void DisplayP3::toSRGB<unsigned char>(
-    std::span<const unsigned char>, std::span<unsigned char>);
+template void DisplayP3::fromSRGB<unsigned char>(std::span<const unsigned char>,
+                                                 std::span<unsigned char>);
+template void DisplayP3::toSRGB<unsigned char>(std::span<const unsigned char>,
+                                               std::span<unsigned char>);
 }  // namespace psm::detail

--- a/src/psm/display_p3/display_p3.cpp
+++ b/src/psm/display_p3/display_p3.cpp
@@ -34,7 +34,7 @@ psm::detail::Mat3f display_p3_2xyz(const psm::detail::Mat3f& src) {
 namespace psm::detail {
 
 template <typename T>
-void DisplayP3::fromSRGB(const std::span<const T>& src, std::span<T> dst) {
+void DisplayP3::fromSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
   psm::detail::RowXf norm_src = transform::srgb::decode(map_src);
 
@@ -58,7 +58,7 @@ void DisplayP3::fromSRGB(const std::span<const T>& src, std::span<T> dst) {
 }
 
 template <typename T>
-void DisplayP3::toSRGB(const std::span<const T>& src, std::span<T> dst) {
+void DisplayP3::toSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
   psm::detail::RowXf norm_src = transform::srgb::decode(map_src);
 
@@ -80,7 +80,7 @@ void DisplayP3::toSRGB(const std::span<const T>& src, std::span<T> dst) {
 }
 
 template void DisplayP3::fromSRGB<unsigned char>(
-    const std::span<const unsigned char>&, std::span<unsigned char>);
+    std::span<const unsigned char>, std::span<unsigned char>);
 template void DisplayP3::toSRGB<unsigned char>(
-    const std::span<const unsigned char>&, std::span<unsigned char>);
+    std::span<const unsigned char>, std::span<unsigned char>);
 }  // namespace psm::detail

--- a/src/psm/include/psm/detail/adobe_rgb.hpp
+++ b/src/psm/include/psm/detail/adobe_rgb.hpp
@@ -11,9 +11,9 @@ class AdobeRgb {
   AdobeRgb() = delete;
 
   template <typename T>
-  static void fromSRGB(const std::span<const T>& src, std::span<T> dst);
+  static void fromSRGB(std::span<const T> src, std::span<T> dst);
   template <typename T>
-  static void toSRGB(const std::span<const T>& src, std::span<T> dst);
+  static void toSRGB(std::span<const T> src, std::span<T> dst);
 };
 
 }  // namespace detail

--- a/src/psm/include/psm/detail/color_space_concept.hpp
+++ b/src/psm/include/psm/detail/color_space_concept.hpp
@@ -7,7 +7,7 @@ namespace psm::detail {
 template <typename Tag>
 concept ColorSpaceType = requires {
   typename Tag::type;  // Must have an implementation type
-} && requires(const std::span<const float>& src, std::span<float> dst) {
+} && requires(std::span<const float> src, std::span<float> dst) {
   // Implementation must have static toSRGB and fromSRGB methods
   // with const source parameter
   { Tag::type::toSRGB(src, dst) } -> std::same_as<void>;

--- a/src/psm/include/psm/detail/display_p3.hpp
+++ b/src/psm/include/psm/detail/display_p3.hpp
@@ -10,9 +10,9 @@ class DisplayP3 {
   DisplayP3() = delete;
 
   template <typename T>
-  static void fromSRGB(const std::span<const T>& src, std::span<T> dst);
+  static void fromSRGB(std::span<const T> src, std::span<T> dst);
   template <typename T>
-  static void toSRGB(const std::span<const T>& src, std::span<T> dst);
+  static void toSRGB(std::span<const T> src, std::span<T> dst);
 };
 }  // namespace detail
 

--- a/src/psm/include/psm/detail/orgb.hpp
+++ b/src/psm/include/psm/detail/orgb.hpp
@@ -10,9 +10,9 @@ class Orgb {
   Orgb() = delete;
 
   template <typename T>
-  static void fromSRGB(const std::span<const T>& src, std::span<T> dst);
+  static void fromSRGB(std::span<const T> src, std::span<T> dst);
   template <typename T>
-  static void toSRGB(const std::span<const T>& src, std::span<T> dst);
+  static void toSRGB(std::span<const T> src, std::span<T> dst);
 };
 
 }  // namespace detail

--- a/src/psm/include/psm/detail/pro_photo_rgb.hpp
+++ b/src/psm/include/psm/detail/pro_photo_rgb.hpp
@@ -11,9 +11,9 @@ class ProPhotoRgb {
   ProPhotoRgb() = delete;
 
   template <typename T>
-  static void fromSRGB(const std::span<const T>& src, std::span<T> dst);
+  static void fromSRGB(std::span<const T> src, std::span<T> dst);
   template <typename T>
-  static void toSRGB(const std::span<const T>& src, std::span<T> dst);
+  static void toSRGB(std::span<const T> src, std::span<T> dst);
 };
 
 }  // namespace detail

--- a/src/psm/include/psm/detail/srgb.hpp
+++ b/src/psm/include/psm/detail/srgb.hpp
@@ -10,13 +10,13 @@ class Srgb {
   Srgb() = delete;
 
   template <typename T>
-  static void fromSRGB(const std::span<const T>& src, std::span<T> dst) {
+  static void fromSRGB(std::span<const T> src, std::span<T> dst) {
     // passthrough because we are already in sRGB
     std::copy(src.begin(), src.end(), dst.begin());
   }
 
   template <typename T>
-  static void toSRGB(const std::span<const T>& src, std::span<T> dst) {
+  static void toSRGB(std::span<const T> src, std::span<T> dst) {
     // passthrough because we are already in sRGB
     std::copy(src.begin(), src.end(), dst.begin());
   }

--- a/src/psm/orgb/orgb.cpp
+++ b/src/psm/orgb/orgb.cpp
@@ -106,7 +106,7 @@ psm::detail::Mat3f orgb2lcc(const psm::detail::Mat3f& orgb) {
 
 namespace psm::detail {
 template <typename T>
-void Orgb::fromSRGB(const std::span<const T>& src, std::span<T> dst) {
+void Orgb::fromSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
   psm::detail::RowXf norm_src = psm::detail::normalize(map_src);
 
@@ -126,7 +126,7 @@ void Orgb::fromSRGB(const std::span<const T>& src, std::span<T> dst) {
 }
 
 template <typename T>
-void Orgb::toSRGB(const std::span<const T>& src, std::span<T> dst) {
+void Orgb::toSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
   psm::detail::RowXf norm_src = psm::detail::normalize(map_src);
 
@@ -146,7 +146,7 @@ void Orgb::toSRGB(const std::span<const T>& src, std::span<T> dst) {
 }
 
 template void Orgb::fromSRGB<unsigned char>(
-    const std::span<const unsigned char>&, std::span<unsigned char>);
-template void Orgb::toSRGB<unsigned char>(const std::span<const unsigned char>&,
+    std::span<const unsigned char>, std::span<unsigned char>);
+template void Orgb::toSRGB<unsigned char>(std::span<const unsigned char>,
                                           std::span<unsigned char>);
 }  // namespace psm::detail

--- a/src/psm/orgb/orgb.cpp
+++ b/src/psm/orgb/orgb.cpp
@@ -145,8 +145,8 @@ void Orgb::toSRGB(std::span<const T> src, std::span<T> dst) {
   dst_map = psm::detail::denormalize_as<T>(result);
 }
 
-template void Orgb::fromSRGB<unsigned char>(
-    std::span<const unsigned char>, std::span<unsigned char>);
+template void Orgb::fromSRGB<unsigned char>(std::span<const unsigned char>,
+                                            std::span<unsigned char>);
 template void Orgb::toSRGB<unsigned char>(std::span<const unsigned char>,
                                           std::span<unsigned char>);
 }  // namespace psm::detail

--- a/src/psm/pro_photo_rgb/pro_photo_rgb.cpp
+++ b/src/psm/pro_photo_rgb/pro_photo_rgb.cpp
@@ -110,6 +110,6 @@ void ProPhotoRgb::toSRGB(std::span<const T> src, std::span<T> dst) {
 
 template void ProPhotoRgb::fromSRGB<unsigned char>(
     std::span<const unsigned char>, std::span<unsigned char>);
-template void ProPhotoRgb::toSRGB<unsigned char>(
-    std::span<const unsigned char>, std::span<unsigned char>);
+template void ProPhotoRgb::toSRGB<unsigned char>(std::span<const unsigned char>,
+                                                 std::span<unsigned char>);
 }  // namespace psm::detail

--- a/src/psm/pro_photo_rgb/pro_photo_rgb.cpp
+++ b/src/psm/pro_photo_rgb/pro_photo_rgb.cpp
@@ -34,7 +34,7 @@ psm::detail::Mat3f pro_photo_rgb2xyz(const psm::detail::Mat3f& src) {
 namespace psm::detail {
 
 template <typename T>
-void ProPhotoRgb::fromSRGB(const std::span<const T>& src, std::span<T> dst) {
+void ProPhotoRgb::fromSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
   psm::detail::RowXf norm_src = transform::srgb::decode(map_src);
 
@@ -71,7 +71,7 @@ void ProPhotoRgb::fromSRGB(const std::span<const T>& src, std::span<T> dst) {
 }
 
 template <typename T>
-void ProPhotoRgb::toSRGB(const std::span<const T>& src, std::span<T> dst) {
+void ProPhotoRgb::toSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
   psm::detail::RowXf norm_src = psm::detail::normalize(map_src);
 
@@ -109,7 +109,7 @@ void ProPhotoRgb::toSRGB(const std::span<const T>& src, std::span<T> dst) {
 }
 
 template void ProPhotoRgb::fromSRGB<unsigned char>(
-    const std::span<const unsigned char>&, std::span<unsigned char>);
+    std::span<const unsigned char>, std::span<unsigned char>);
 template void ProPhotoRgb::toSRGB<unsigned char>(
-    const std::span<const unsigned char>&, std::span<unsigned char>);
+    std::span<const unsigned char>, std::span<unsigned char>);
 }  // namespace psm::detail

--- a/src/psm/srgb/srgb.cpp
+++ b/src/psm/srgb/srgb.cpp
@@ -2,8 +2,8 @@
 
 namespace psm::detail {
 
-template void Srgb::fromSRGB<unsigned char>(
-    std::span<const unsigned char>, std::span<unsigned char>);
+template void Srgb::fromSRGB<unsigned char>(std::span<const unsigned char>,
+                                            std::span<unsigned char>);
 template void Srgb::toSRGB<unsigned char>(std::span<const unsigned char>,
                                           std::span<unsigned char>);
 }  // namespace psm::detail

--- a/src/psm/srgb/srgb.cpp
+++ b/src/psm/srgb/srgb.cpp
@@ -3,7 +3,7 @@
 namespace psm::detail {
 
 template void Srgb::fromSRGB<unsigned char>(
-    const std::span<const unsigned char>&, std::span<unsigned char>);
-template void Srgb::toSRGB<unsigned char>(const std::span<const unsigned char>&,
+    std::span<const unsigned char>, std::span<unsigned char>);
+template void Srgb::toSRGB<unsigned char>(std::span<const unsigned char>,
                                           std::span<unsigned char>);
 }  // namespace psm::detail


### PR DESCRIPTION
## What
This PR removes unnecessary references to `std::span` parameters in color space conversion functions throughout the library.
## Why
`std::span` is a lightweight view type that's cheap to copy, so passing it by reference doesn't provide any performance benefits and can make the code more complex. Following best practices for modern C++, we should pass `std::span` by value.
## How
- Updated all color space implementation headers to use `std::span `by value instead of using `const std::span<const T>&`
- Updated all implementation files to match the new function signatures
- Updated the `ColorSpaceType` concept to reflect the new parameter types

## Related Issues
Closes #90 