### PR TITLE
feat: add BUILD_PSM_CLI option for flexible builds

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,11 +42,14 @@ Assuming that the VCPKG_ROOT is set:
    $ cmake --list-presets
    ```
 2. Use a preset to configure
+
    ```bash
    $ cmake --preset <preset-name>
    ```
 
-   By default, this will build all available modules. To build only specific modules, use the WITH flags:
+   By default, this will build all available modules. To build only specific
+   modules, use the WITH flags:
+
    ```bash
    # Build with only oRGB support
    $ cmake --preset <preset-name> -DWITH_ORGB=ON
@@ -58,7 +61,18 @@ Assuming that the VCPKG_ROOT is set:
    $ cmake --preset <preset-name> -DWITH_ORGB=ON -DWITH_ADOBE_RGB=ON
    ```
 
+   You can control whether the PSM CLI tool is built:
+
+   ```bash
+   # Disable building PSM CLI (build only the library)
+   $ cmake --preset <preset-name> -DBUILD_PSM_CLI=OFF
+
+   # Enable building PSM CLI (default)
+   $ cmake --preset <preset-name> -DBUILD_PSM_CLI=ON
+   ```
+
    You can also control whether tests are built:
+
    ```bash
    # Disable building tests
    $ cmake --preset <preset-name> -DBUILD_TESTING=OFF
@@ -89,4 +103,6 @@ $ cd build/<preset-name>
 $ ctest
 ```
 
-Note that tests are only built for modules that are being built. For example, if you only build the Adobe RGB module with `-DWITH_ADOBE_RGB=ON`, only the Adobe RGB tests will be available.
+Note that tests are only built for modules that are being built. For example, if
+you only build the Adobe RGB module with `-DWITH_ADOBE_RGB=ON`, only the Adobe
+RGB tests will be available.

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -20,9 +20,10 @@ install(
           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
           COMPONENT applications)
 
-# Install CLI tool
-install(TARGETS psm_cli RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-                                COMPONENT applications)
+if(BUILD_PSM_CLI)
+  install(TARGETS psm_cli RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                                  COMPONENT applications)
+endif()
 
 # Run ldconfig on Unix systems
 if(UNIX)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -1,5 +1,8 @@
 set(PSM_MODULES adjust_channels orgb adobe_rgb display_p3 pro_photo_rgb)
 
+# Option to control whether psm_cli is built
+option(BUILD_PSM_CLI "Build the PSM CLI tool" ON)
+
 # Dynamically create WITH_<module> options
 foreach(module ${PSM_MODULES})
   string(TOUPPER "${module}" MODULE_UPPER) # Convert to uppercase for

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_subdirectory(psm)
-add_subdirectory(psm_cli)
+
+if(BUILD_PSM_CLI)
+  add_subdirectory(psm_cli)
+endif()


### PR DESCRIPTION
## What
* Added a new CMake option **BUILD_PSM_CLI** that allows users to control whether the PSM CLI tool is built alongside the core library.
* Created a boolean option that defaults to ON
* Added conditional builds and installation based on this flag
*Updated documentation to explain the new option
## Why
* Flexibility for users who only need the core library functionality
* Improves integration experience when PSM is used as a dependency in other projects
* Reduces build time and binary size for users who don't need the CLI tool
## How
Added option declaration in Options.cmake with default value of ON
Modified src/CMakeLists.txt to conditionally include the psm_cli directory
Updated Install.cmake to conditionally install the CLI executable
Added clear documentation in INSTALL.md with examples of how to use the option