### PR TITLE
feat(psm): add 16-bit pixel support to core library

### DIFF
--- a/src/psm/adjust_channels/adjust_channels.cpp
+++ b/src/psm/adjust_channels/adjust_channels.cpp
@@ -1,13 +1,15 @@
 #include "psm/adjust_channels.hpp"
 
 #include <Eigen/Dense>
+#include <cstdint>
+
+#include "psm/detail/pixel_transformation.hpp"
 
 namespace psm::detail {
 
 template <typename T>
 void adjustChannels(std::span<T> buffer, const Percent& adjust_percentage) {
   Eigen::Map<Eigen::RowVectorX<T>> map_src(buffer.data(), buffer.size());
-
   Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 3, Eigen::RowMajor>> split_src(
       map_src.data(), buffer.size() / 3, 3);
 
@@ -16,14 +18,20 @@ void adjustChannels(std::span<T> buffer, const Percent& adjust_percentage) {
       static_cast<float>(adjust_percentage.channel(1)) / 100.0f,
       static_cast<float>(adjust_percentage.channel(2)) / 100.0f;
 
-  split_src = (split_src.template cast<float>().array() *
-               (1.0f + adjustments.replicate(split_src.rows(), 1)))
-                  .cwiseMin(255.0f)
-                  .cwiseMax(0.0f)
-                  .template cast<T>();
+  Eigen::MatrixXf normalized_src = normalize_pixels(split_src);
+  Eigen::MatrixXf adjusted =
+      (normalized_src.array() *
+       (1.0f + adjustments.replicate(split_src.rows(), 1)))
+          .cwiseMin(1.0f)
+          .cwiseMax(0.0f);
+
+  split_src = denormalize_as<T>(adjusted);
 }
 
 template void adjustChannels<unsigned char>(std::span<unsigned char>,
+                                            const Percent&);
+
+template void adjustChannels<std::uint16_t>(std::span<std::uint16_t>,
                                             const Percent&);
 
 }  // namespace psm::detail

--- a/src/psm/adobe_rgb/adobe_rgb.cpp
+++ b/src/psm/adobe_rgb/adobe_rgb.cpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Dense>
 #include <cmath>
+#include <cstdint>
 
 #include "psm/detail/colorspace.hpp"
 #include "psm/detail/pixel_transformation.hpp"
@@ -81,4 +82,9 @@ template void AdobeRgb::fromSRGB<unsigned char>(std::span<const unsigned char>,
                                                 std::span<unsigned char>);
 template void AdobeRgb::toSRGB<unsigned char>(std::span<const unsigned char>,
                                               std::span<unsigned char>);
+
+template void AdobeRgb::fromSRGB<std::uint16_t>(std::span<const std::uint16_t>,
+                                                std::span<std::uint16_t>);
+template void AdobeRgb::toSRGB<std::uint16_t>(std::span<const std::uint16_t>,
+                                              std::span<std::uint16_t>);
 }  // namespace psm::detail

--- a/src/psm/display_p3/display_p3.cpp
+++ b/src/psm/display_p3/display_p3.cpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Dense>
 #include <cmath>
+#include <cstdint>
 
 #include "psm/detail/colorspace.hpp"
 #include "psm/detail/pixel_transformation.hpp"
@@ -83,4 +84,9 @@ template void DisplayP3::fromSRGB<unsigned char>(std::span<const unsigned char>,
                                                  std::span<unsigned char>);
 template void DisplayP3::toSRGB<unsigned char>(std::span<const unsigned char>,
                                                std::span<unsigned char>);
+
+template void DisplayP3::fromSRGB<std::uint16_t>(std::span<const std::uint16_t>,
+                                                 std::span<std::uint16_t>);
+template void DisplayP3::toSRGB<std::uint16_t>(std::span<const std::uint16_t>,
+                                               std::span<std::uint16_t>);
 }  // namespace psm::detail

--- a/src/psm/orgb/orgb.cpp
+++ b/src/psm/orgb/orgb.cpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Dense>
 #include <cmath>
+#include <cstdint>
 #include <numbers>
 
 #include "psm/detail/pixel_transformation.hpp"
@@ -108,7 +109,7 @@ namespace psm::detail {
 template <typename T>
 void Orgb::fromSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
-  psm::detail::RowXf norm_src = psm::detail::normalize(map_src);
+  psm::detail::RowXf norm_src = psm::detail::normalize_pixels(map_src);
 
   // Assuming RGB/BGR as input
   const psm::detail::Mat3fView norm_rgb(norm_src.data(), norm_src.cols() / 3,
@@ -128,7 +129,7 @@ void Orgb::fromSRGB(std::span<const T> src, std::span<T> dst) {
 template <typename T>
 void Orgb::toSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
-  psm::detail::RowXf norm_src = psm::detail::normalize(map_src);
+  psm::detail::RowXf norm_src = psm::detail::normalize_pixels(map_src);
 
   // Assuming RGB/BGR as input for oRGB
   psm::detail::Mat3fView norm_orgb(norm_src.data(), norm_src.cols() / 3, 3);
@@ -149,4 +150,9 @@ template void Orgb::fromSRGB<unsigned char>(std::span<const unsigned char>,
                                             std::span<unsigned char>);
 template void Orgb::toSRGB<unsigned char>(std::span<const unsigned char>,
                                           std::span<unsigned char>);
+
+template void Orgb::fromSRGB<std::uint16_t>(std::span<const std::uint16_t>,
+                                            std::span<std::uint16_t>);
+template void Orgb::toSRGB<std::uint16_t>(std::span<const std::uint16_t>,
+                                          std::span<std::uint16_t>);
 }  // namespace psm::detail

--- a/src/psm/pro_photo_rgb/pro_photo_rgb.cpp
+++ b/src/psm/pro_photo_rgb/pro_photo_rgb.cpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Dense>
 #include <cmath>
+#include <cstdint>
 
 #include "psm/detail/colorspace.hpp"
 #include "psm/detail/pixel_transformation.hpp"
@@ -73,7 +74,7 @@ void ProPhotoRgb::fromSRGB(std::span<const T> src, std::span<T> dst) {
 template <typename T>
 void ProPhotoRgb::toSRGB(std::span<const T> src, std::span<T> dst) {
   const Eigen::Map<const Eigen::RowVectorX<T>> map_src(src.data(), src.size());
-  psm::detail::RowXf norm_src = psm::detail::normalize(map_src);
+  psm::detail::RowXf norm_src = psm::detail::normalize_pixels(map_src);
 
   psm::detail::RowXf decoded_pro_photo = norm_src.unaryExpr([](float value) {
     return (value < 16.0f / 512.0f) ? (value / 16.0f) : (std::pow(value, 1.8f));
@@ -112,4 +113,9 @@ template void ProPhotoRgb::fromSRGB<unsigned char>(
     std::span<const unsigned char>, std::span<unsigned char>);
 template void ProPhotoRgb::toSRGB<unsigned char>(std::span<const unsigned char>,
                                                  std::span<unsigned char>);
+
+template void ProPhotoRgb::fromSRGB<std::uint16_t>(
+    std::span<const std::uint16_t>, std::span<std::uint16_t>);
+template void ProPhotoRgb::toSRGB<std::uint16_t>(std::span<const std::uint16_t>,
+                                                 std::span<std::uint16_t>);
 }  // namespace psm::detail


### PR DESCRIPTION
- Refactor normalize() to normalize_pixels() with type-aware scaling
- Replace hardcoded 255.0f limits with std::numeric_limits<T>::max()
- Add std::uint16_t template instantiations for all color spaces:
  - AdobeRgb, DisplayP3, ProPhotoRgb, Orgb, adjustChannels
- Update pixel transformation functions to handle arbitrary bit depths
- Add type trait constraints for unsigned integral and floating types

This enables the library to process both 8-bit and 16-bit images while maintaining backward compatibility with existing 8-bit workflows.